### PR TITLE
Switches the Docker base image to hlapp/rpopgen from Docker Hub

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,22 +1,18 @@
-## Start with the hadleyverse image from Rocker, then add population
-## genetics images on top.
+## Start with the Population Genetics in R image, which is essentially
+## rocker/hadleyverse with population genetics R packages layered on top.
 
-FROM rocker/hadleyverse:latest
+FROM hlapp/rpopgen:latest
 MAINTAINER Hilmar Lapp hilmar.lapp@duke.edu
 
 ## Install population genetics and related packages from CRAN
-RUN rm -rf /tmp/*.rds \
-&&  install2.r --error \
-    ape \
-    adegenet \
-    hierfstat \
-    knitcitations \
-    pegas \
-    mmod \
-    genetics \
-    phylobase \
-    phytools \
-&& rm -rf /tmp/downloaded_packages/ /tmp/*.rds
+## (currently all in the base image)
+# RUN rm -rf /tmp/*.rds \
+# &&  install2.r --error \
+## add package here
+# && rm -rf /tmp/downloaded_packages/ /tmp/*.rds
 
 ## Install population genetics and related packages from Github
-# RUN installGithub.r 
+## (currently all in the base image)
+# RUN installGithub.r \
+## add package here
+# && rm -rf /tmp/downloaded_packages/

--- a/circle.yml
+++ b/circle.yml
@@ -8,13 +8,8 @@ general:
             - gh-pages
 
 dependencies:
-    cache_directories:
-        - "~/docker"
-
     override:
-        - if [[ -e ~/docker/popgenImage.tar ]]; then docker load -i ~/docker/popgenImage.tar; fi
         - cd build && docker build -t rocker/popgen - < Dockerfile
-        - mkdir -p ~/docker; docker save rocker/popgen > ~/docker/popgenImage.tar
 
 checkout:
     post:


### PR DESCRIPTION
This should significantly reduce build time, as the Rpopgen layer is now pre-built on Docker Hub. See [hlapp/rpopgen](https://registry.hub.docker.com/u/hlapp/rpopgen/) for more info on the pre-build base image.