### PR TITLE
Documentation about how the build works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,37 @@
+##
+## Prerequisites and how this works ##
+##
+## Rendering the HTML files from .md and .Rmd input files will be run
+## within a Docker container. The benefit of this is that the
+## rendering will run in a software environment that is highly
+## consistent between otherwise vastly different machines, and you do
+## not need to worry about installing the numerous components (R, a
+## variety of R packages, TeX/LaTeX, pandoc, etc) of this environment
+## yourself. It does mean, however, that docker must be able to
+## run. On non-Linux systems, this will require having VirtualBox or
+## another VM hosting software installed and started up, which is
+## typically accomplished through executing boot2docker. You may need
+## to set some environment variables after that; your boot2docker
+## program will usually tell you what to do.
+##
+## Once you have prepared your environment for running docker, you can
+## test the build by issuing 'make test', which at present is
+## synonymous with 'make html'. I.e., the website build is tested by
+## rendering all HTML content.
+##
+## The website is built in the build/ directory by first copying there
+## all .md and .Rmd files from the root directory and a list of
+## subdirectories, followed by running rmarkdown::render from within
+## R.
+##
+## The deployment of the website, currently hosted on Github Pages, is
+## initiated, but not completed by 'make deploy'. This will create a
+## TAR archive of the website content. At present, pushing the archive
+## contents to Github Pages is done by the Continuous Integration (CI)
+## server (see circle.yml for details), though you may of course also
+## do so by hand if you have the necessary permissions.
+## 
+
 TARGETS := $(filter-out README.md, $(wildcard *.Rmd *.md))
 
 all: clean html
@@ -7,7 +41,7 @@ export BUILDDIR := $(CURDIR)/build
 export DATADIR  := $(CURDIR)/data
 export REPODIR  := $(CURDIR)
 
-html: cpsources $(SUBDIRS)
+html test: cpsources $(SUBDIRS)
 	$(MAKE) -C $(BUILDDIR) html
 
 deploy: html

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ This site provides resources for conducting population genetic analyses in R usi
 
 Any member of the R user community proficient in population genetics is welcome to contibute to this site. See [here](CONTRIBUTING.md) for instructions on how to contribute workflow vignettes using [R markdown](R_MARKDOWN.md).
 
-This site was developed during the [Population Genetics R hackathon] held at NESCent on March 16-20, 2015. 
+This site was developed during the [Population Genetics in R hackathon]
+held at [NESCent] March 16-20, 2015.
 
 ## Prerequisites and how this works ##
 
@@ -38,6 +39,7 @@ ability to run GNU `make`.
 For further details on the mechanics of the build and deploy process,
 see the documentation in the top-level [Makefile](Makefile).
 
+[NESCent]: http://nescent.org
 [Population Genetics R hackathon]: https://github.com/NESCent/r-popgen-hackathon
 [R markdown]: http://rmarkdown.rstudio.com/
 [Circle CI]: http://circleci.com

--- a/README.md
+++ b/README.md
@@ -11,4 +11,35 @@ This site provides resources for conducting population genetic analyses in R usi
 
 Any member of the R user community proficient in population genetics is welcome to contibute to this site. See [here](CONTRIBUTING.md) for instructions on how to contribute workflow vignettes using [R markdown](R_MARKDOWN.md).
 
-This site was developed during the [Population Genetics R hackathon](https://github.com/NESCent/r-popgen-hackathon) held at NESCent on March 16-20, 2015. 
+This site was developed during the [Population Genetics R hackathon] held at NESCent on March 16-20, 2015. 
+
+## Prerequisites and how this works ##
+
+The content of this resource is authored in Markdown and [R markdown]
+documents, which are rendered to HTML and published to a Github
+Pages-hosted static website. The rendering requires a complex software
+environment (R, a variety of R packages, TeX/LaTeX, pandoc, etc). To
+allow this to run as consistently as possible between someone's local
+machine and the Continuous Integration (CI) platform (currently
+[Circle CI]) that automatically builds and deploys the website upon
+changes, the rendering is done from within a [Docker] container that has
+everything preinstalled (see the [Dockerfile](build/Dockerfile)).
+
+As a consequence, contributors need not worry about installing the
+numerous necssary software components themselves, but to build the
+site locally, one has to have docker set up to run. See
+[Docker installation guides], then click on the "Installation" tab and
+choose your OS to learn about how to get Docker installed and running
+on your system.
+
+In addition to Docker, building the HTML content locally requires the
+ability to run GNU `make`.
+
+For further details on the mechanics of the build and deploy process,
+see the documentation in the top-level [Makefile](Makefile).
+
+[Population Genetics R hackathon]: https://github.com/NESCent/r-popgen-hackathon
+[R markdown]: http://rmarkdown.rstudio.com/
+[Circle CI]: http://circleci.com
+[Docker]: https://www.docker.com/whatisdocker/
+[Docker installation guides]: https://docs.docker.com/

--- a/build/Makefile
+++ b/build/Makefile
@@ -18,6 +18,9 @@ html: dockerImage $(HTML_FILES)
 
 deploy: html
 	tar cf $(SITEARCH) include libs *.html *_files
+## The following shouldn't have to be run from within Docker, but
+## there is a weird permission error for .png images (rendered plots)
+## on the Circle CI server if run outside of the container.
 	docker run -v $(REPODIR):/repo -w /repo/build rocker/popgen make distclean
 
 .PHONY: dockerImage


### PR DESCRIPTION
Documentation about prerequisites for and mechanics about the rendering of the site from the sources.

Also, synonymized `test` as a make target with `html`, for the benefit of people who are using to saying `make test`.