### PR TITLE
Fix code in vignettes to pass tests after CRAN package changes

### DIFF
--- a/use/DifferentiationSNP.Rmd
+++ b/use/DifferentiationSNP.Rmd
@@ -79,7 +79,7 @@ object (Mydata2)
 ```{r,data_conversion}
 
 locus <- Mydata[, -c(1, 2, 3, 4, 25:ncol(Mydata))] 
-Mydata1 <- df2genind(locus, ploidy = 2, ind.names = ind, pop = population)
+Mydata1 <- df2genind(locus, ploidy = 2, ind.names = ind, pop = population,ncode=2)
 Mydata1
 Mydata2 <- genind2hierfstat(Mydata1) 
 

--- a/use/DifferentiationSNP.Rmd
+++ b/use/DifferentiationSNP.Rmd
@@ -89,7 +89,8 @@ Mydata2 <- genind2hierfstat(Mydata1)
 ## $F_{st}$ (observed and expected heterozygosity)  (package hierfstat)
 
 ```{r,Basicstatiscis_with Fst}
-basic.stats(Mydata2) # Fst following Nei (1987)
+basic.stats(Mydata1) # Fst following Nei (1987) on genind object
+basic.stats(Mydata2) # same as previous, on hierfstat object
 wc(Mydata2) # Weir and Cockrham estimate
 ```
 
@@ -114,8 +115,7 @@ test.between(loci, test.lev = population, rand.unit = county, nperm = 30)
 ### Pairwise $F_{st}$ (package hierfstat)
 
 ```{r,pairewise_Fst}
-loci1 <- na.omit(loci)
-pp.fst(loci1, diploid = TRUE) # Do not work with missing values
+genet.dist(Mydata1, method="WC84")
 # No test at the moment
 ```
 

--- a/use/DifferentiationSNP.Rmd
+++ b/use/DifferentiationSNP.Rmd
@@ -79,7 +79,7 @@ object (Mydata2)
 ```{r,data_conversion}
 
 locus <- Mydata[, -c(1, 2, 3, 4, 25:ncol(Mydata))] 
-Mydata1 <- df2genind(locus, ploidy = 2, ind.names = ind, pop = population,ncode=2)
+Mydata1 <- df2genind(locus, ploidy = 2, ind.names = ind, pop = population, sep="")
 Mydata1
 Mydata2 <- genind2hierfstat(Mydata1) 
 


### PR DESCRIPTION
From @smanel:
> I added the option ncode=2 in the command df2genind. But the command genind2hierfstat still does not work.