### PR TITLE
ignore .Renviron files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ install/*html
 develop/*_files/
 use/*_files/
 install/*_files/
+
+# ignore .Renviron file
+.Renviron


### PR DESCRIPTION
This is an addition that would help with utilizing git2r as a resource for contribution. Adding .Renviron to the ignore list allows users to create a file called `.Renviron`, which will allow them to store a [personal access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/) that [git2r can use with the function `cred_token()`](https://twitter.com/ZKamvar/status/674467963563466754).

Here's an example .Renviron file that would take advantage of this:

```
GITHUB_PAT="<40-character-string>"
```

When R is started, it will look for the .Renviron file inside the working directory and then in the home directory if one doesn't exist. It will set any environmental variables it finds. The advantage of a PAT is that it can be regenerated on the fly. @hlapp, I'm looking for your approval here.