### PR TITLE
add H1 padding

### DIFF
--- a/build/include/in_header.html
+++ b/build/include/in_header.html
@@ -45,6 +45,10 @@ body {
   padding-bottom: 40px;
 }
 /* offset scroll position for anchor links (for fixed navbar)  */
+.section h1 {
+  padding-top: 55px;
+  margin-top: -55px;
+}
 .section h2 {
   padding-top: 55px;
   margin-top: -55px;


### PR DESCRIPTION
I noticed if you click on a link in the TOC for a page, if that
link happens to be an h1, there's no padding and it gets hidden
behind the navbar. This padding *should* prevent that from
happening.