### PR TITLE
Add Code of Conduct

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,0 +1,25 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, we pledge to respect all people who 
+contribute through reporting issues, posting feature requests, updating documentation,
+submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for
+everyone, regardless of level of experience, gender, gender identity and expression,
+sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual language or
+imagery, derogatory comments or personal attacks, trolling, public or private harassment,
+insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments,
+commits, code, wiki edits, issues, and other contributions that are not aligned to this 
+Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed 
+from the project team.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by 
+opening an issue or contacting one or more of the project maintainers.
+
+This Code of Conduct is adapted from the Contributor Covenant 
+(http:contributor-covenant.org), version 1.0.0, available at 
+http://contributor-covenant.org/version/1/0/0/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,3 +58,7 @@ Since this process requires git, if you are having trouble installing git or acc
 # How do I submit datasets?
 
 We encourage contributors to use existing data sets for their vignettes. If uploading your data set to this repository, submit data files to the **data/** directory in your branch in the same way as for your R markdown file. The data set used in a vignette should be **< 200kb** in size. If your data set is larger and your analysis will make sense on a subset of the data set, then please subset it to a smaller size for both submission and use in the vignette. 
+
+# Code of Conduct
+
+Please note that this project is released with a [Contributor Code of Conduct](CONDUCT.html). By participating in this project you agree to abide by its terms.

--- a/README.md
+++ b/README.md
@@ -45,3 +45,6 @@ see the documentation in the top-level [Makefile](Makefile).
 [Circle CI]: http://circleci.com
 [Docker]: https://www.docker.com/whatisdocker/
 [Docker installation guides]: https://docs.docker.com/
+
+
+Please note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.


### PR DESCRIPTION
As this project is public and GitHub doubles as a social network, a code of conduct is an important preventative measure to avoid any form of abuse by reviewers or contributors.