### PR TITLE
Add DESCRIPTION file

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,0 +1,31 @@
+Package: popgenInfo
+Title: popgenInfo is not really an R package, but this is here to list the dependencies for building the ggplot2 book.
+Version: 0.1
+Authors@R: person("First", "Last", email = "first.last@example.com",
+                  role = c("aut", "cre"))
+Depends: R (>= 3.1.0)
+URL: https://nescent.github.io/popgenInfo
+Imports:
+  apex,
+  ape,
+  adegenet,
+  pegas,
+  coalescentMCMC,
+  mmod,
+  poppr,
+  strataG,
+  rmetasim,
+  genetics,
+  hierfstat,
+  pcadapt,
+  outFLANK,
+  knitcitations,
+  phangorn,
+  phylobase,
+  phytools
+Suggests:
+  BioStrings,
+  qvalue
+SystemRequirements: pandoc (>= 1.12.3) - http://johnmacfarlane.net/pandoc
+Remotes:
+  whitlock/OutFLANK

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Version: 0.1
 Authors@R: person("First", "Last", email = "first.last@example.com",
                   role = c("aut", "cre"))
 Depends: R (>= 3.1.0)
-URL: https://nescent.github.io/popgenInfo
+URL: https://github.com/NESCent/popgenInfo
 Imports:
   apex,
   ape,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Imports:
   genetics,
   hierfstat,
   pcadapt,
-  outFLANK,
+  OutFLANK,
   knitcitations,
   phangorn,
   phylobase,
@@ -27,5 +27,6 @@ Suggests:
   BioStrings,
   qvalue
 SystemRequirements: pandoc (>= 1.12.3) - http://johnmacfarlane.net/pandoc
-Remotes:
+Remotes: 
   whitlock/OutFLANK
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,12 @@
 Package: popgenInfo
 Title: popgenInfo is not really an R package, but this is here to list the dependencies for building the ggplot2 book.
 Version: 0.1
-Authors@R: person("First", "Last", email = "first.last@example.com",
-                  role = c("aut", "cre"))
+Authors: Zhian N. Kamvar,
+  Margarita M. López-Uribe,
+  Simone Coughan,
+  Niklaus J. Grünwald,
+  Hilmar Lapp,
+  Stéphanie Manel
 Depends: R (>= 3.1.0)
 URL: https://github.com/NESCent/popgenInfo
 Imports:
@@ -29,4 +33,4 @@ Suggests:
 SystemRequirements: pandoc (>= 1.12.3) - http://johnmacfarlane.net/pandoc
 Remotes: 
   whitlock/OutFLANK
-
+Encoding: UTF-8


### PR DESCRIPTION
This allows the NESCent repository to be seen as a package so that all of the dependencies can be installed. Inspiration comes from https://github.com/hadley/ggplot2-book

This will allow the users to have a consistent environment:

```r
install.packages("devtools", repos = "https://cran.r-project.org")
# devtools::install_github("NESCent/popgenInfo")
devtools::install_github("zkamvar/popgenInfo@as-package")
```
