### PR TITLE
Ensures that circle.yml isn't deleted from gh-pages.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -27,6 +27,7 @@ deployment:
             - make deploy
             - git checkout gh-pages
             - rm -r *
+            - git checkout master -- circle.yml
             - tar xvf .site.tar
             - git add --all
             - git commit -m "Website rebuild"


### PR DESCRIPTION
If it is, CircleCI complains, see #138. This change will also ensure that circle.yml will stay up to date with the version on master.

Fixes #138 when merged.