### PR TITLE
add check.names argument to data input

### DIFF
--- a/use/2015-05-18-Dist-SNP.Rmd
+++ b/use/2015-05-18-Dist-SNP.Rmd
@@ -46,13 +46,13 @@ accordingly.
 
 ```{r, data_import_df_show, eval = FALSE}
 
-Mydata <- read.table("Master_Pinus_data_genotype.txt", header = TRUE)   
+Mydata <- read.table("Master_Pinus_data_genotype.txt", header = TRUE, check.names = FALSE)   
 dim(Mydata) 
 ```
 
 ```{r, data_import_df_run, echo = FALSE}
 
-Mydata <- read.table("../data/Master_Pinus_data_genotype.txt", header = TRUE)   
+Mydata <- read.table("../data/Master_Pinus_data_genotype.txt", header = TRUE, check.names = FALSE)   
 dim(Mydata) 
 ```
 

--- a/use/DifferentiationSNP.Rmd
+++ b/use/DifferentiationSNP.Rmd
@@ -48,12 +48,12 @@ AT...).
 When you import the data, you need to be in the right directory.
 
 ```{r, data_import_df_show, eval = FALSE}
-Mydata <- read.table("Master_Pinus_data_genotype.txt", header = TRUE)   
+Mydata <- read.table("Master_Pinus_data_genotype.txt", header = TRUE, check.names = FALSE)   
 dim(Mydata) 
 ```
 ```{r, data_import_df_do, echo = FALSE}
 # You should be in the right directory
-Mydata <- read.table("../data/Master_Pinus_data_genotype.txt", header = TRUE)   
+Mydata <- read.table("../data/Master_Pinus_data_genotype.txt", header = TRUE, check.names = FALSE)   
 dim(Mydata) 
 ```
 


### PR DESCRIPTION
This is an update for the new adegenet version.

the alleles are named with x-y-z. When R reads them in, they are converted to x.y.z, which results in an error from adegenet because it uses a [LOCUS].[ALLELE] syntax, which is thrown off by extra periods.

Additionally, this should allow #146 to pass check.