### PR TITLE
Attempts to fix the build timeout on Circle.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -26,7 +26,7 @@ deployment:
         commands:
             - make deploy
             - git checkout gh-pages
-            - rm -r *
+            - rm -rf *
             - git checkout master -- circle.yml
             - tar xvf .site.tar
             - git add --all


### PR DESCRIPTION
More precisely, fix the deploy step timeout. The build actually succeeds, which presumably is why there wasn't any issue with the test on PR #143. The build with failed deploy step is here:
https://circleci.com/gh/NESCent/popgenInfo/428

The odd thing here is that nobody changed the jquery copy, so it's not clear why this would be write-protected now if it wasn't before.

The integration test for this PR is somewhat bogus, because the failing step (deployment of rebuilt website) is not (and, until we create a development server, arguably cannot be) actually part of the tests conducted for a PR.