### PR TITLE
attempt to add images to deploy

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -27,7 +27,7 @@ html: dockerImage $(HTML_FILES)
 	$(SUDO) docker run --user="$(USERID):$(GROUPID)" -e "HOME=/tmp" -v $(REPODIR):/repo -w /repo/build rocker/popgen Rscript -e "rmarkdown::render('$<')"
 
 deploy: html
-	tar cf $(SITEARCH) include libs *.html *_files
+	tar cf $(SITEARCH) include libs *.html *_files ../images
 
 .PHONY: dockerImage
 


### PR DESCRIPTION
I do not know if this would work, but this would allow people to
include images by specifying `![](../images/img.png)` as opposed to
placing the entire URL of the master branch, where the image would
not exist.

@hlapp, would this work?
