### PR TITLE
Adds provision to keep custom domain name definition.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,6 +29,7 @@ deployment:
             - git checkout gh-pages
             - rm -r *
             - git checkout master -- circle.yml
+            - git checkout gh-pages -- CNAME
             - tar xvf .site.tar
             - git add --all
             - git commit -m "Website rebuild"


### PR DESCRIPTION
This change is, and unfortunately cannot be self contained, because it depends on second change on a different branch, namely the commit 728b6e1acfd53a39fff83eac7166ea624e982c1a on `gh-pages` that introduces the CNAME file.

I should note that this PR will need to be merged before any others, because the next site rebuild will erase the CNAME file from the `gh-pages` branch if it isn't this one.